### PR TITLE
[PLAT-624] - Include group deploy for update to env-* files

### DIFF
--- a/build_push/build_push.sh
+++ b/build_push/build_push.sh
@@ -35,7 +35,7 @@ then
     if [ -z "${TAG_OVERRIDE:-}" ];
     then
         #If build action is triggered after the release, get the updated version from package file and set it as the image tag in stack file
-        PACKAGE_VERSION="$(cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[",]//g' | tr -d '[[:space:]]')"
+        PACKAGE_VERSION="$(cat package.json | sed 's/.*"version": "\(.*\)".*/\1/;t;d')"
         FUNCTION_PATH="$(cat package.json | grep name | head -1 | awk -F: '{ print $2 }' | sed 's/[",]//g' | tr -d '[[:space:]]')"
         UPDATED_STACK_FILE="$(yq w "$STACK_FILE" functions."$FUNCTION_PATH".image "$GCR_ID""$FUNCTION_PATH":"$PACKAGE_VERSION")"
         echo "$UPDATED_STACK_FILE" > $STACK_FILE
@@ -87,7 +87,7 @@ else
                         if [ -z "${TAG_OVERRIDE:-}" ];
                         then
                             # Get the updated version from the package.json file
-                            cd "$FUNCTION_PATH" && PACKAGE_VERSION=$(cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[",]//g' | tr -d '[[:space:]]')
+                            cd "$FUNCTION_PATH" && PACKAGE_VERSION=$(cat package.json | sed 's/.*"version": "\(.*\)".*/\1/;t;d')
                             # Write the updated version into stack file image properties tag
                             cd .. && UPDATED_STACK_FILE=$(yq w "$STACK_FILE" functions."$FUNCTION_PATH".image "$GCR_ID""$FUNCTION_PATH":"$PACKAGE_VERSION")
                             echo "$UPDATED_STACK_FILE" > $STACK_FILE

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -153,12 +153,15 @@ else
                     groupDeployFuncs=($GROUP_FUNCTIONS)
                     for func in "${groupDeployFuncs[@]}"
                     do
-                      yq p -i "$func/$COMMITTED_FILES" "functions"."$func"
-                      # Get the updated image tag if the tag is not latest
-                      IMAGE_TAG=$(yq r "$func/$COMMITTED_FILES" functions."$func".image)
-                      touch updated_stack.yml
-                      yq w -i "$func/$COMMITTED_FILES" functions."$func".image "$GCR_ID""$IMAGE_TAG"
-                      yq merge -i updated_stack.yml "$func/$COMMITTED_FILES"
+                      if [ "$func" != 'template' ];
+                      then
+                          yq p -i "$func/$COMMITTED_FILES" "functions"."$func"
+                          # Get the updated image tag if the tag is not latest
+                          IMAGE_TAG=$(yq r "$func/$COMMITTED_FILES" functions."$func".image)
+                          touch updated_stack.yml
+                          yq w -i "$func/$COMMITTED_FILES" functions."$func".image "$GCR_ID""$IMAGE_TAG"
+                          yq merge -i updated_stack.yml "$func/$COMMITTED_FILES"
+                      fi
                     done
                     yq merge -i updated_stack.yml stack.yml
                     cp -f updated_stack.yml stack.yml


### PR DESCRIPTION
- Deploys all the functions in the group path to target environment based on the file updated, Dev/staging/prod environment for update to env-dev/staging.prod.yml 
- if env-staging.yml is updated ---> All the function specific image properties, environment variables in staging-deploy.yml will be leveraged for deploying to staging. Similarly works the same for updates to env-prod.yml/env-dev.yml files.